### PR TITLE
update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,13 +8,13 @@ description = "Library that facilitates monitoring Git repositories for changes.
 repository = "https://github.com/rawkode/gitsync"
 
 [dependencies]
-git2 = "0.16"
+git2 = "0.18"
 log = "0.4"
 
 [dev-dependencies]
 async-trait = "0.1"
-cucumber = { version = "0.19" }
-tempfile = "3.4"
+cucumber = { version = "0.20" }
+tempfile = "3.10"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 
 [[test]]


### PR DESCRIPTION
Dependabot on comtrya's repo highlights a vulnerability rated with high severity (8.6/10) due to the transitive depenency on libgit2-sys. This PR is mainly focused on dumping the dependency on git2 so that way libgit2-sys is a high enough version to fix the vulnerability. I also went ahead and did the minor version bumps on other packages.